### PR TITLE
Add disk monitoring playbook with alert documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # ansible
+
+## Disk Monitoring with Alerts
+
+The `disk_monitor.yml` playbook checks a host's disk usage and sends alerts when the usage exceeds a specified threshold. Alerts are delivered by email, Slack notification, and a local log entry.
+
+### Prerequisites
+1. Ansible installed on the control machine.
+2. A valid inventory of target hosts.
+3. SMTP access and a Slack token for notifications.
+
+### Setup
+1. **Configure variables** in `disk_monitor.yml`:
+   - `disk`: filesystem to check (default `/`).
+   - `threshold`: usage percentage that triggers an alert.
+   - `email_to` and `email_from`: addresses for email alerts.
+   - `smtp_host` and `smtp_port`: mail server settings.
+   - `slack_token` and `slack_channel`: Slack credentials.
+   - `log_file`: path for log warnings.
+2. **Run the playbook**:
+   ```bash
+   ansible-playbook -i inventory disk_monitor.yml
+   ```
+3. If disk usage exceeds the threshold, Ansible will:
+   - Send an email using the `mail` module.
+   - Post a Slack message with `community.general.slack`.
+   - Write a warning to the chosen log file.
+
+### Example Inventory
+```ini
+[servers]
+server1.example.com
+server2.example.com
+```
+
+### Automating with Cron
+To check disks every hour, create a cron job:
+```bash
+0 * * * * ansible-playbook -i /path/to/inventory /path/to/disk_monitor.yml
+```

--- a/disk_monitor.yml
+++ b/disk_monitor.yml
@@ -1,0 +1,53 @@
+---
+- name: Monitor disk usage
+  hosts: all
+  gather_facts: yes
+  vars:
+    disk: "/"
+    threshold: 80
+    email_to: "admin@example.com"
+    email_from: "monitor@example.com"
+    smtp_host: "smtp.example.com"
+    smtp_port: 25
+    slack_token: "YOUR_SLACK_TOKEN"
+    slack_channel: "#alerts"
+    log_file: "/var/log/disk_usage_alerts.log"
+
+  tasks:
+    - name: Get disk usage
+      command: "df -P {{ disk }} | tail -1 | awk '{print $5}'"
+      register: df_out
+      changed_when: false
+
+    - name: Set usage percent
+      set_fact:
+        usage_percent: "{{ df_out.stdout.rstrip('%') | int }}"
+
+    - name: Debug usage
+      debug:
+        msg: "Disk usage on {{ disk }} is {{ usage_percent }}%"
+
+    - name: Send email alert if threshold exceeded
+      mail:
+        host: "{{ smtp_host }}"
+        port: "{{ smtp_port }}"
+        to: "{{ email_to }}"
+        from: "{{ email_from }}"
+        subject: "Disk usage alert on {{ inventory_hostname }}"
+        body: "Disk usage on {{ disk }} is {{ usage_percent }}%, exceeding threshold of {{ threshold }}%."
+      when: usage_percent > threshold
+
+    - name: Send Slack notification if threshold exceeded
+      community.general.slack:
+        token: "{{ slack_token }}"
+        channel: "{{ slack_channel }}"
+        msg: "Disk usage on {{ inventory_hostname }} {{ disk }} is {{ usage_percent }}% (threshold {{ threshold }}%)."
+      when: usage_percent > threshold
+
+    - name: Write warning to log file
+      lineinfile:
+        path: "{{ log_file }}"
+        create: yes
+        line: "{{ ansible_date_time.iso8601 }} {{ inventory_hostname }} {{ disk }} usage {{ usage_percent }}%"
+      when: usage_percent > threshold
+      delegate_to: localhost


### PR DESCRIPTION
## Summary
- add `disk_monitor.yml` playbook to monitor disk usage
- update `README.md` with guide on configuring and running disk monitoring

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850f719cda0832193e1e59292ddab3c