### PR TITLE
Add Ansible user management playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ To check disks every hour, create a cron job:
 ```bash
 0 * * * * ansible-playbook -i /path/to/inventory /path/to/disk_monitor.yml
 ```
+
+## User Management
+
+The `user_management.yml` playbook creates or removes user accounts and sets up groups, passwords, and SSH keys.
+
+### Usage
+1. Edit the variables at the top of `user_management.yml` to define the account name, groups, password, and SSH key.
+2. Run the playbook:
+   ```bash
+   ansible-playbook -i inventory user_management.yml
+   ```

--- a/user_management.yml
+++ b/user_management.yml
@@ -1,0 +1,31 @@
+---
+- name: Manage users and groups
+  hosts: all
+  become: yes
+  vars:
+    username: example
+    groups:
+      - developers
+    state: present  # use 'absent' to remove
+    password: "{{ 'securepassword' | password_hash('sha512') }}"
+    ssh_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC...user@example"
+  tasks:
+    - name: Ensure groups exist
+      group:
+        name: "{{ item }}"
+        state: present
+      loop: "{{ groups }}"
+
+    - name: Manage user account
+      user:
+        name: "{{ username }}"
+        groups: "{{ groups | join(',') }}"
+        state: "{{ state }}"
+        password: "{{ password }}"
+
+    - name: Set authorized SSH key for the user
+      authorized_key:
+        user: "{{ username }}"
+        state: present
+        key: "{{ ssh_key }}"
+      when: state == 'present'


### PR DESCRIPTION
## Summary
- add playbook `user_management.yml` to manage user accounts, groups, passwords, and SSH keys
- document the new playbook in README

## Testing
- `ansible-playbook --syntax-check disk_monitor.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f99dacf08321bb517be142be93a3