### PR TITLE
Add Ansible service management playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,27 @@ The `user_management.yml` playbook creates or removes user accounts and sets up 
    ```bash
    ansible-playbook -i inventory user_management.yml
    ```
+
+## Service Management
+
+The `service_management.yml` playbook starts, stops, enables, or disables
+services on target hosts.
+
+### Usage
+1. Edit the `services` list in `service_management.yml` to define each
+   service name, desired state, and whether it should be enabled at boot.
+2. Run the playbook:
+   ```bash
+   ansible-playbook -i inventory service_management.yml
+   ```
+
+Example structure for `services`:
+```yaml
+services:
+  - name: nginx
+    state: started
+    enabled: true
+  - name: sshd
+    state: stopped
+    enabled: false
+```

--- a/service_management.yml
+++ b/service_management.yml
@@ -1,0 +1,16 @@
+---
+- name: Manage system services
+  hosts: all
+  become: yes
+  vars:
+    services:
+      - name: nginx
+        state: started
+        enabled: true
+  tasks:
+    - name: Manage services
+      service:
+        name: "{{ item.name }}"
+        state: "{{ item.state }}"
+        enabled: "{{ item.enabled | default(omit) }}"
+      loop: "{{ services }}"


### PR DESCRIPTION
## Summary
- add `service_management.yml` to manage system services
- document new playbook in README

## Testing
- `ansible-playbook --syntax-check service_management.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa8a50c08321ab2c41e2688efda9