### PR TITLE
Add automated system updates playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,16 @@ services:
     state: stopped
     enabled: false
 ```
+
+## System Updates
+
+The `system_update.yml` playbook installs the latest package updates and
+security patches on target hosts. It can reboot machines when required.
+
+### Usage
+1. Set the `reboot` variable to `true` if you want hosts to reboot after
+   applying updates when a reboot is needed.
+2. Run the playbook:
+   ```bash
+   ansible-playbook -i inventory system_update.yml
+   ```

--- a/system_update.yml
+++ b/system_update.yml
@@ -1,0 +1,46 @@
+---
+- name: Apply system updates
+  hosts: all
+  become: yes
+  vars:
+    reboot: false  # set to true to reboot automatically if updates require it
+  tasks:
+    - name: Update packages on Debian/Ubuntu
+      apt:
+        upgrade: dist
+        update_cache: yes
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Update packages on RedHat/CentOS
+      yum:
+        name: '*'
+        state: latest
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Check if reboot is required on Debian/Ubuntu
+      stat:
+        path: /var/run/reboot-required
+      register: reboot_required_file
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Check if reboot is required on RedHat/CentOS
+      command: needs-restarting -r
+      register: reboot_required_cmd
+      changed_when: false
+      failed_when: false
+      when: ansible_facts['os_family'] == 'RedHat'
+
+    - name: Determine if reboot is needed
+      set_fact:
+        reboot_required: >-
+          {{ reboot_required_file.stat.exists | default(false) or
+             (reboot_required_cmd.rc == 1) | default(false) }}
+
+    - name: Reboot if required
+      reboot:
+        msg: "Reboot initiated by Ansible after updates"
+        connect_timeout: 5
+        reboot_timeout: 600
+      when:
+        - reboot
+        - reboot_required


### PR DESCRIPTION
## Summary
- automate package updates across Debian and RedHat families
- reboot hosts when updates require it
- document the new playbook

## Testing
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850feca5a5c8321b3cd277165ca01b9