### PR TITLE
Add baseline audit playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ security patches on target hosts. It can reboot machines when required.
    ```bash
    ansible-playbook -i inventory system_update.yml
    ```
+
+## System Baseline Audit
+
+The `system_baseline_audit.yml` playbook collects basic system information and appends it to a log file. The entry includes hostname, operating system version, kernel release, and system uptime.
+
+### Usage
+1. Adjust the `log_file` variable in the playbook if a different log location is desired.
+2. Run the playbook:
+   ```bash
+   ansible-playbook -i inventory system_baseline_audit.yml
+   ```

--- a/system_baseline_audit.yml
+++ b/system_baseline_audit.yml
@@ -1,0 +1,17 @@
+---
+- name: Collect and log system baseline information
+  hosts: all
+  gather_facts: yes
+  vars:
+    log_file: /var/log/system_baseline.log
+  tasks:
+    - name: Compose baseline log entry
+      set_fact:
+        baseline_entry: "{{ ansible_date_time.iso8601 }} hostname={{ ansible_fqdn }} os={{ ansible_distribution }} {{ ansible_distribution_version }} kernel={{ ansible_kernel }} uptime={{ ansible_uptime_seconds }}s"
+
+    - name: Append baseline entry to log file
+      lineinfile:
+        path: "{{ log_file }}"
+        create: yes
+        line: "{{ baseline_entry }}"
+      delegate_to: localhost


### PR DESCRIPTION
## Summary
- add `system_baseline_audit.yml` playbook to capture OS details
- document the baseline audit playbook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851265c2d4c8321b05d98f84451e57f