### PR TITLE
Add process monitor playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,16 @@ The `system_baseline_audit.yml` playbook collects basic system information and a
    ```bash
    ansible-playbook -i inventory system_baseline_audit.yml
    ```
+
+
+## Process Monitoring
+
+The `process_monitor.yml` playbook verifies that specified processes are running on your hosts.
+
+### Usage
+1. Edit the `processes` list in `process_monitor.yml` with the names of processes you want to monitor.
+2. Run the playbook:
+   ```bash
+   ansible-playbook -i inventory process_monitor.yml
+   ```
+

--- a/process_monitor.yml
+++ b/process_monitor.yml
@@ -1,0 +1,20 @@
+---
+- name: Monitor critical processes
+  hosts: all
+  gather_facts: no
+  vars:
+    processes:
+      - sshd
+      - nginx
+  tasks:
+    - name: Check if process is running
+      shell: pgrep -fl "{{ item }}"
+      register: process_status
+      changed_when: false
+      failed_when: false
+      loop: "{{ processes }}"
+
+    - name: Report process status
+      debug:
+        msg: "{{ item.item }} is {{ 'running' if item.rc == 0 else 'NOT running' }}"
+      loop: "{{ process_status.results }}"


### PR DESCRIPTION
## Summary
- add a simple playbook to check running processes
- document process monitoring in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68512f25aff483219618a6b1a84bba0f